### PR TITLE
security: CORS allowlist; enable rate limit; auth on /metrics

### DIFF
--- a/koa-api.js
+++ b/koa-api.js
@@ -23,8 +23,33 @@ const app = new Koa();
 
 // app.context.redis = client;
 
-// Middleware
-app.use(cors());
+// CORS allowlist. Source from ALLOWED_ORIGINS env (comma-separated).
+// Defaults cover the Hyr production hostnames + local dev. NEVER call
+// `cors()` with no options — that reflects any Origin and, combined
+// with credentialed callers, exposes every authenticated route.
+const ALLOWED_ORIGINS = (
+	process.env.ALLOWED_ORIGINS ||
+	[
+		'https://candidate.hyr.works',
+		'https://hyr-api.hyr.works',
+		'https://interviewer.hyr.works',
+		'https://app.hyr.works',
+		'https://admin.hyr.works',
+		'http://localhost:3000',
+		'http://localhost:4000',
+		'http://localhost:8000',
+	].join(',')
+).split(',').map(s => s.trim()).filter(Boolean);
+
+app.use(cors({
+	origin: (ctx) => {
+		const requestOrigin = ctx.get('Origin');
+		return ALLOWED_ORIGINS.includes(requestOrigin) ? requestOrigin : '';
+	},
+	credentials: true,
+	allowHeaders: ['Authorization', 'Content-Type', 'X-Requested-With'],
+	allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+}));
 app.use(bodyParser());
 app.use(updateMetrics)
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -39,36 +39,50 @@ async function validateUser(ctx, next) {
 	await next();
 };
 
+// In-memory sliding-window rate limit. Per-process — fine for a single
+// broker instance. Move to Redis if we ever scale this horizontally.
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const RATE_LIMIT_MAX = parseInt(process.env.RATE_LIMIT_PER_HOUR || '100', 10);
+const rateLimitBuckets = new Map(); // userId -> [timestamps]
+
+function pruneBucket(timestamps, now) {
+	const cutoff = now - RATE_LIMIT_WINDOW_MS;
+	while (timestamps.length && timestamps[0] < cutoff) timestamps.shift();
+}
+
 async function checkRateLimit(ctx, next) {
-	
-	// const user = ctx.state.user;
+	const user = ctx.state.user;
+	if (!user) {
+		throw new Error('checkRateLimit requires validateUser to have populated ctx.state.user first');
+	}
 
-	// if (!user) { throw Error("checkRateLimit could not get the user object. Make sure previous middleware added it to ctx.state.user before calling checkRateLimit") }
+	const now = Date.now();
+	let timestamps = rateLimitBuckets.get(user.id);
+	if (!timestamps) {
+		timestamps = [];
+		rateLimitBuckets.set(user.id, timestamps);
+	}
+	pruneBucket(timestamps, now);
 
-	// const key = `rate_limit:${user.id}`;
-	// const windowSeconds = 60 * 60; // 1 hour
-	// const limit = 100;
-	// const replies = await ctx.redis.multi()
-	// 	.incr(key)
-	// 	.expire(key, windowSeconds)
-	// 	.get(key)
-	// 	.exec((err, replies) => {
-	// 		if (err) {
-	// 			console.error(' - ‼️ redis error: ' + err);
-	// 		} else {
-	// 			console.log(replies)
-	// 		}
-	// 	});
-	
-	// const currentRequests = parseInt(replies[2]);
+	if (timestamps.length >= RATE_LIMIT_MAX) {
+		const retryAfterSec = Math.max(1, Math.ceil((timestamps[0] + RATE_LIMIT_WINDOW_MS - now) / 1000));
+		ctx.set('Retry-After', String(retryAfterSec));
+		ctx.status = 429;
+		ctx.body = { error: 'Rate limit exceeded. Try again later.', message: null };
+		return;
+	}
 
-	// if (currentRequests > limit) {
-	// 	ctx.status = 429;
-	// 	ctx.body = { error: 'GPT Rate limit exceeded. Try again later.', message: null }
-	// 	return;
-	// }
-
+	timestamps.push(now);
 	await next();
 }
+
+// Periodically drop empty buckets so the Map doesn't grow unbounded.
+setInterval(() => {
+	const now = Date.now();
+	for (const [id, timestamps] of rateLimitBuckets) {
+		pruneBucket(timestamps, now);
+		if (timestamps.length === 0) rateLimitBuckets.delete(id);
+	}
+}, 10 * 60 * 1000).unref?.();
 
 export { validateUser, checkRateLimit, updateMetrics };

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto"
 import Router from "koa-router"
 import { validateUser, checkRateLimit } from "./middleware.js"
 import { generateResponse, generateResponseStream } from "./openaiChatCompletions.js"
@@ -17,7 +18,27 @@ router.get('/health', async ctx => {
 })
 
 
+// Prometheus metrics. Locked behind a shared token so we don't leak
+// internal request volume / model usage / failure rates publicly.
+// If METRICS_TOKEN is unset, the endpoint 404s (don't reveal existence).
 router.get('/metrics', async ctx => {
+	const expected = process.env.METRICS_TOKEN;
+	if (!expected) {
+		ctx.status = 404;
+		ctx.body = { error: 'Endpoint not found' };
+		return;
+	}
+	const provided = ctx.get('X-Metrics-Token');
+	const expectedBuf = Buffer.from(expected, 'utf8');
+	const providedBuf = Buffer.from(provided || '', 'utf8');
+	if (
+		expectedBuf.length !== providedBuf.length ||
+		!crypto.timingSafeEqual(expectedBuf, providedBuf)
+	) {
+		ctx.status = 401;
+		ctx.body = { error: 'Unauthorized' };
+		return;
+	}
 	ctx.type = 'text/plain';
 	ctx.body = await register.metrics();
 })


### PR DESCRIPTION
## Summary
Three independent hardening fixes to the GPT broker.

**1. CORS allowlist** (`koa-api.js`)
- `app.use(cors())` was reflecting any `Origin`. Replaced with an explicit allowlist sourced from `ALLOWED_ORIGINS` env (comma-separated), defaulting to the Hyr production hostnames + local dev ports.
- `allowHeaders` tightened to `Authorization, Content-Type, X-Requested-With`.

**2. Re-enable rate limiting** (`src/middleware.js`)
- The body of `checkRateLimit` was entirely commented out — every authenticated route had no limiter at all. Token-cost DoS was a real risk.
- Replaced with an in-memory sliding window: 100 req/hour/user by default (`RATE_LIMIT_PER_HOUR` env to override). Per-process, fine for a single broker instance. If we ever scale horizontally, swap for Redis.
- Returns `429` with `Retry-After`.

**3. Auth on `/metrics`** (`src/routes.js`)
- Prometheus metrics were public — request counts, model usage, failure rates exposed to anyone.
- Now requires `X-Metrics-Token: <METRICS_TOKEN>` (compared via `crypto.timingSafeEqual`). If `METRICS_TOKEN` is unset, the endpoint 404s (don't reveal existence).

## Deploy notes
- **Set `METRICS_TOKEN`** in env if your monitoring stack scrapes `/metrics`. Update the scrape config to send the header. Without this, scraping breaks (returns 404).
- Optionally set `ALLOWED_ORIGINS` if production hostnames differ from the defaults.
- `RATE_LIMIT_PER_HOUR` defaults to 100. Adjust if needed.

## Test plan
- [ ] `curl /metrics` without header → 401 (or 404 if `METRICS_TOKEN` unset).
- [ ] `curl -H "X-Metrics-Token: <correct>" /metrics` → 200 with Prometheus output.
- [ ] Authenticated user calling `/v2/advanced-gpt-4o-mini-complete` 101+ times in an hour starts getting 429.
- [ ] Browser fetch from `https://attacker.example` is blocked at preflight; from an allowlisted origin succeeds.

## Out of scope
- Move rate limit to Redis for multi-instance deployments.
- Replace the leaked `SUPABASE_SERVICE_KEY` env (covered by credential rotation runbook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a metrics endpoint for API monitoring and performance tracking

* **Security**
  * Restricted cross-origin requests to an allowlisted set of approved origins
  * Implemented per-hour rate limiting to protect API resources and prevent abuse

<!-- end of auto-generated comment: release notes by coderabbit.ai -->